### PR TITLE
Deploy modules

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -55,6 +55,7 @@ import utility
 import utility_redcap
 import plugins
 import module
+from module import deploy_module
 
 @task(alias='backup')
 def backup_database(options=""):

--- a/module.py
+++ b/module.py
@@ -1,6 +1,7 @@
 from fabric.api import *
 import os
 import re
+import utility
 import urllib.request
 
 def module_exists(module_name, repo_base="ctsit"):
@@ -14,19 +15,17 @@ def module_exists(module_name, repo_base="ctsit"):
 def get_latest_release_tag(module_name, repo_base="ctsit"):
     tag = ""
 
-    # Check the module exists
-    if(module_exists(module_name, repo_base)):
-        url = "https://api.github.com/repos/%s/%s/tags" %(repo_base, module_name)
+    url = "https://api.github.com/repos/%s/%s/tags" %(repo_base, module_name)
 
-        with hide('output', 'running', 'warnings'):
-            tags = run("curl -s %s | grep name | cut -d '\"' -f 4 | sort --version-sort -r" %(url))
+    with hide('output', 'running', 'warnings'):
+        tags = run("curl -s %s | grep name | cut -d '\"' -f 4 | sort --version-sort -r" %(url))
         tag = tags.split('\n')[0]
         tag = tag.rstrip()
 
-        if(tag == ""):
-            print("The module %s/%s hasn't been tagged." %(repo_base, module_name))
-        else:
-            print("The tag for module %s/%s is %s." %(repo_base, module_name, tag))
+    if(tag == ""):
+        print("The module %s/%s hasn't been tagged." %(repo_base, module_name))
+    else:
+        print("The tag for module %s/%s is %s." %(repo_base, module_name, tag))
     return tag
 
 def get_latest_release_zip(module_name, repo_base="ctsit"):
@@ -44,11 +43,17 @@ def get_latest_release_zip(module_name, repo_base="ctsit"):
         abort("The module %s/%s doesn't exist." %(repo_base, module_name))
 
 @task
-def deploy_module(module_name, module_version="", repo_base="ctsit"):
+def deploy_module(module_input, module_version="", repo_base="ctsit"):
     """
     Deploy module to the specified host without enabling it.
     If no module_version is provided the latest version is deployed.
     """
+
+    module_array = module_input.split('/')
+    if (len(module_array) == 2):
+        repo_base, module_name = module_array
+    else:
+        module_name = module_input
 
     file_name = get_latest_release_zip(module_name, repo_base)
     #file_name = "project_ownership_v1.2.1"

--- a/module.py
+++ b/module.py
@@ -13,6 +13,9 @@ def module_exists(module_name, repo_base="ctsit"):
     return output
 
 def get_latest_release_tag(module_name, repo_base="ctsit"):
+    """
+    Defaults to latest release
+    """
     tag = ""
 
     url = "https://api.github.com/repos/%s/%s/tags" %(repo_base, module_name)
@@ -35,7 +38,7 @@ def get_latest_release_zip(module_name, repo_base="ctsit"):
             abort("The module %s/%s has not been released yet." %(repo_base, module_name))
 
         url = "https://github.com/%s/%s/archive/%s.zip" %(repo_base, module_name, tag)
-        file_name = "%s_v%s" %(module_name, tag)
+        file_name = "%s_v%s" %(module_name, re.sub('[^\d^\.]', '', tag)) # regex replace anything in tag except x.y.z
         urllib.request.urlretrieve(url, file_name + '.zip')
 
         return file_name
@@ -43,20 +46,20 @@ def get_latest_release_zip(module_name, repo_base="ctsit"):
         abort("The module %s/%s doesn't exist." %(repo_base, module_name))
 
 @task
-def deploy_module(module_input, module_version="", repo_base="ctsit"):
+def deploy_module(module_input, module_version="", upload_module_version = ""):
     """
     Deploy module to the specified host without enabling it.
     If no module_version is provided the latest version is deployed.
     """
-
+    module_input = module_input.split('github.com/')[-1]
     module_array = module_input.split('/')
     if (len(module_array) == 2):
         repo_base, module_name = module_array
     else:
         module_name = module_input
+        repo_base = "ctsit"
 
     file_name = get_latest_release_zip(module_name, repo_base)
-    #file_name = "project_ownership_v1.2.1"
 
     with settings(user=env.deploy_user):
     # Make a temp folder to upload the tar to


### PR DESCRIPTION
Works as outlined in examples from https://github.com/ctsit/redcap_deployment/issues/39

i.e.  
`fab <instance> deploy_module:<repo_owner>/<repo>,<github_tag>,<version_label_in_upload>` 
 
`<repo_owner>` defaults to `ctsit`, `<github_tag>` defaults to the latest tag, `<version_label_in_upload>` defaults to be the same as `<github_tag>` but scrubs it to remove everything but digits and decimals so REDCap will allow its activation.  
`<repo_owner>/<repo>` can be replaced with `https://github.com/<repo_owner>/<repo>` as in the example for easy copy-paste.

I'm unsure if this works with an `instance` other than `vagrant`, I tried `redcapstage`'s `stage_c` but needed a password for the `deploy` user so I could not test.

`enable_module` seems to already be in place in the form of `enable` so I'm misunderstanding what it's meant to do.

Next step is to add the plurality of these functions, but I figured this needed testing first.